### PR TITLE
feat(api): add heat-ranked /v1/sitemap endpoint backed by Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ SQLite を直接使用できない環境向けに、Go + Gin 製の **OpenAPI-fi
 | `GET /v1/search/definitions?q=snow` | 語釈の全文検索（FTS5） |
 | `GET /v1/random?count=5` | ランダム取得 |
 | `GET /v1/entries/{uuid}` | UUID で取得 |
+| `GET /v1/sitemap?page=1&page_size=1000` | 全語彙を熱度順にページング（sitemap 用） |
 | `GET /v1/metadata` ・ `GET /healthz` | メタデータ・ヘルスチェック |
 | `GET /docs` | API ドキュメント（Redoc） |
 

--- a/api/README.md
+++ b/api/README.md
@@ -17,8 +17,10 @@ read-only な API で、単一の `genji.db`（SQLite + FTS5）を参照する�
 | `GET /v1/search/entries` | 見出し語・読みの全文検索（FTS5） | query: `q`（必須）, `limit`（既定50, 上限200） |
 | `GET /v1/search/definitions` | 語釈(gloss)の全文検索（FTS5） | query: `q`（必須）, `limit`（既定50, 上限200） |
 | `GET /v1/random` | ランダム取得 | query: `count`（既定5, 上限100） |
+| `GET /v1/sitemap` | 全語彙を熱度順にページング | query: `page`（既定1）, `page_size`（既定1000, 上限50000） |
 | `GET /openapi.yaml` | OpenAPI 仕様（バイナリ同梱） | — |
 | `GET /docs` | API ドキュメント（Redoc） | — |
+| `GET /robots.txt` | クローラ拒否（前端へ誘導） | — |
 
 ### リクエスト例
 
@@ -63,9 +65,12 @@ API 仕様の全体はサーバー起動後にブラウザで `http://localhost:
 | `GENJI_REDIS_PASSWORD` | （空） | Redis パスワード |
 | `GENJI_REDIS_DB` | `0` | Redis DB 番号 |
 | `GENJI_CACHE_TTL` | `1h` | キャッシュ TTL（`time.ParseDuration` 形式、例 `30m`） |
+| `GENJI_HEAT_AGG_INTERVAL` | `15m` | 熱度ランキングの集計間隔 |
+| `GENJI_HEAT_W30` | `2` | 直近30日アクセス数の重み |
+| `GENJI_HEAT_W365` | `1` | 直近365日アクセス数の重み |
 
-> **キャッシュは任意**。`GENJI_REDIS_ADDR` が未設定、または Redis に接続できない場合は
-> 自動的にキャッシュ無効（Noop）で動作する。API の可用性は Redis に依存しない。
+> **キャッシュ・熱度は任意**。`GENJI_REDIS_ADDR` が未設定、または Redis に接続できない場合は
+> キャッシュ無効・熱度無効（sitemap は DB 順フォールバック）で動作する。API の可用性は Redis に依存しない。
 
 ## キャッシュの仕組み
 
@@ -112,6 +117,44 @@ read-only な辞書 API なので、クエリ結果を Redis にキャッシュ�
 即時反映したい場合は、TTL を短くするか、デプロイ時に Redis をフラッシュする。
 キーは `genji:v1:` プレフィックスで名前空間化されているため、`redis-cli --scan --pattern 'genji:v1:*'` で
 まとめて確認・削除できる。
+
+> なお `GET /v1/sitemap` の各ページも短 TTL（`min(GENJI_CACHE_TTL, 集計間隔)`）でキャッシュされる
+> （キー `genji:v1:sitemap:{page_size}:{page}`）。
+
+## 熱度ランキング（sitemap）
+
+`GET /v1/sitemap` は前端の sitemap 生成用に、**全収録語彙を熱度（人気度）の降順**でページングして返す。
+熱度はアクセス数を Redis でカウントして算出する（`internal/heat`）。
+
+### 熱度の定義
+
+```
+heat = GENJI_HEAT_W30 × (直近30日のアクセス数) + GENJI_HEAT_W365 × (直近365日のアクセス数)
+     = 2 × c30 + 1 × c365   （既定）
+```
+
+- 365日窓は30日窓を**含む**。よって直近30日のアクセスは実質 3 倍、31〜365日は 1 倍。
+- 「アクセス」としてカウントするのは `GET /v1/entries/{uuid}` / `GET /v1/lookup/entry` / `GET /v1/lookup/reading`
+  で**返った各語の uuid**（検索結果は対象外）。記録は非同期・ベストエフォート。
+
+### Redis データモデルと集計
+
+| キー | 用途 |
+|---|---|
+| `genji:hits:day:{YYYYMMDD}` | その日の語ごとのアクセス数（ZSET, TTL 366日） |
+| `genji:entries:all` | 全 uuid を 0 点で保持する土台（起動時に DB から seed） |
+| `genji:heat:index` | 集計済みランキング（ZSET, uuid→heat）。sitemap が `ZREVRANGE` で読む |
+
+- バックグラウンドで `GENJI_HEAT_AGG_INTERVAL`（既定 15分）ごとに集計：
+  直近30日 / 365日の day キーを `ZUNIONSTORE` で合算し、重み付けして `genji:heat:index` を再構築する。
+- 多重インスタンスでの重複集計は `genji:heat:agg:lock`（SETNX）で防ぐ。
+- DB バージョン（`_metadata.version`）が変わると `genji:entries:all` を再 seed する。
+
+### Redis 無効時のフォールバック
+
+`GENJI_REDIS_ADDR` 未設定・接続失敗時は、`/v1/sitemap` は DB の安定順
+（`freq_rank` 昇順 → 見出し語順）で全件をページングし、`heat` は `null` を返す。
+エンドポイント自体は常に動作する。
 
 ## ローカル開発
 

--- a/api/cmd/genji-api/main.go
+++ b/api/cmd/genji-api/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Iktahana/Genji/api/internal/api"
 	"github.com/Iktahana/Genji/api/internal/cache"
 	"github.com/Iktahana/Genji/api/internal/config"
+	"github.com/Iktahana/Genji/api/internal/heat"
+	"github.com/Iktahana/Genji/api/internal/redisx"
 	"github.com/Iktahana/Genji/api/internal/server"
 	"github.com/Iktahana/Genji/api/internal/store"
 )
@@ -30,10 +32,22 @@ func main() {
 	defer st.Close()
 	log.Printf("database opened: %s", cfg.DBPath)
 
-	c := cache.New(cfg.RedisAddr, cfg.RedisPassword, cfg.RedisDB)
-	defer c.Close()
+	// Redis クライアントは一度だけ生成し cache / heat で共有する（nil = 無効）。
+	rdb := redisx.Connect(cfg.RedisAddr, cfg.RedisPassword, cfg.RedisDB)
+	if rdb != nil {
+		defer rdb.Close()
+	}
+	c := cache.NewWithClient(rdb)
+	hsvc := heat.New(rdb, cfg.HeatW30, cfg.HeatW365, cfg.HeatAggInterval)
 
-	handler := server.NewHandler(st, c, cfg.CacheTTL)
+	// 熱度ランキングの土台 seed + 集計ループ起動（Redis 有効時のみ実体が動く）。
+	aggCtx, aggCancel := context.WithCancel(context.Background())
+	defer aggCancel()
+	if hsvc.Enabled() {
+		startHeat(aggCtx, st, hsvc)
+	}
+
+	handler := server.NewHandler(st, c, hsvc, cfg.CacheTTL)
 
 	router := newRouter(handler)
 
@@ -60,6 +74,20 @@ func main() {
 	if err := srv.Shutdown(ctx); err != nil {
 		log.Printf("shutdown error: %v", err)
 	}
+}
+
+// startHeat は DB バージョンに基づく seed を行い、集計ループを起動する。
+func startHeat(ctx context.Context, st *store.Store, hsvc heat.Service) {
+	version := ""
+	if m, err := st.Metadata(); err == nil && m.Version != nil {
+		version = *m.Version
+	}
+	if uuids, err := st.AllUUIDs(); err != nil {
+		log.Printf("heat: failed to load uuids for seed: %v", err)
+	} else if err := hsvc.Seed(ctx, uuids, version); err != nil {
+		log.Printf("heat: seed failed: %v", err)
+	}
+	hsvc.StartAggregator(ctx)
 }
 
 func newRouter(handler *server.Handler) *gin.Engine {

--- a/api/go.mod
+++ b/api/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
@@ -51,6 +52,7 @@ require (
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	github.com/woodsbury/decimal128 v1.4.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,4 +1,6 @@
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
@@ -181,6 +183,8 @@ github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN
 github.com/woodsbury/decimal128 v1.4.0 h1:xJATj7lLu4f2oObouMt2tgGiElE5gO6mSWUjQsBgUlc=
 github.com/woodsbury/decimal128 v1.4.0/go.mod h1:BP46FUrVjVhdTbKT+XuQh2xfQaGki9LMIRJSFuh6THU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=

--- a/api/internal/api/genji.gen.go
+++ b/api/internal/api/genji.gen.go
@@ -162,6 +162,30 @@ type SensoryTags struct {
 	Temperature *string   `json:"temperature,omitempty"`
 }
 
+// SitemapItem defines model for SitemapItem.
+type SitemapItem struct {
+	Entry string `json:"entry"`
+
+	// Heat 熱度指数（2×直近30日 + 1×直近365日のアクセス数）。Redis 無効時は null
+	Heat           *float64 `json:"heat,omitempty"`
+	ReadingPrimary *string  `json:"reading_primary,omitempty"`
+
+	// UpdatedAt エントリの更新日時（sitemap の lastmod 用）
+	UpdatedAt *string `json:"updated_at,omitempty"`
+	Uuid      string  `json:"uuid"`
+}
+
+// SitemapPage defines model for SitemapPage.
+type SitemapPage struct {
+	Items    []SitemapItem `json:"items"`
+	Page     int           `json:"page"`
+	PageSize int           `json:"page_size"`
+
+	// Total 全収録語彙数
+	Total      int `json:"total"`
+	TotalPages int `json:"total_pages"`
+}
+
 // LookupByEntryParams defines parameters for LookupByEntry.
 type LookupByEntryParams struct {
 	// Word 見出し語（漢字・カタカナ等）
@@ -198,6 +222,15 @@ type SearchEntriesParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// GetSitemapParams defines parameters for GetSitemap.
+type GetSitemapParams struct {
+	// Page ページ番号（1 始まり）
+	Page *int `form:"page,omitempty" json:"page,omitempty"`
+
+	// PageSize 1 ページあたりの件数
+	PageSize *int `form:"page_size,omitempty" json:"page_size,omitempty"`
+}
+
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
 	// ヘルスチェック
@@ -224,6 +257,9 @@ type ServerInterface interface {
 	// 見出し語・読みを全文検索
 	// (GET /v1/search/entries)
 	SearchEntries(c *gin.Context, params SearchEntriesParams)
+	// 全収録語彙を熱度順にページングして取得
+	// (GET /v1/sitemap)
+	GetSitemap(c *gin.Context, params GetSitemapParams)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -437,6 +473,41 @@ func (siw *ServerInterfaceWrapper) SearchEntries(c *gin.Context) {
 	siw.Handler.SearchEntries(c, params)
 }
 
+// GetSitemap operation middleware
+func (siw *ServerInterfaceWrapper) GetSitemap(c *gin.Context) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetSitemapParams
+
+	// ------------- Optional query parameter "page" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "page", c.Request.URL.Query(), &params.Page, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "page_size" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "page_size", c.Request.URL.Query(), &params.PageSize, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_size: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetSitemap(c, params)
+}
+
 // GinServerOptions provides options for the Gin server.
 type GinServerOptions struct {
 	BaseURL      string
@@ -472,6 +543,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/v1/random", wrapper.RandomEntries)
 	router.GET(options.BaseURL+"/v1/search/definitions", wrapper.SearchDefinitions)
 	router.GET(options.BaseURL+"/v1/search/entries", wrapper.SearchEntries)
+	router.GET(options.BaseURL+"/v1/sitemap", wrapper.GetSitemap)
 }
 
 type GetHealthRequestObject struct {
@@ -676,6 +748,28 @@ func (response SearchEntries200JSONResponse) VisitSearchEntriesResponse(w http.R
 	return err
 }
 
+type GetSitemapRequestObject struct {
+	Params GetSitemapParams
+}
+
+type GetSitemapResponseObject interface {
+	VisitGetSitemapResponse(w http.ResponseWriter) error
+}
+
+type GetSitemap200JSONResponse SitemapPage
+
+func (response GetSitemap200JSONResponse) VisitGetSitemapResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
 	// ヘルスチェック
@@ -702,6 +796,9 @@ type StrictServerInterface interface {
 	// 見出し語・読みを全文検索
 	// (GET /v1/search/entries)
 	SearchEntries(ctx context.Context, request SearchEntriesRequestObject) (SearchEntriesResponseObject, error)
+	// 全収録語彙を熱度順にページングして取得
+	// (GET /v1/sitemap)
+	GetSitemap(ctx context.Context, request GetSitemapRequestObject) (GetSitemapResponseObject, error)
 }
 
 type StrictHandlerFunc func(ctx *gin.Context, request any) (any, error)
@@ -958,6 +1055,32 @@ func (sh *strictHandler) SearchEntries(ctx *gin.Context, params SearchEntriesPar
 		sh.options.HandlerErrorFunc(ctx, err)
 	} else if validResponse, ok := response.(SearchEntriesResponseObject); ok {
 		if err := validResponse.VisitSearchEntriesResponse(ctx.Writer); err != nil {
+			sh.options.ResponseErrorHandlerFunc(ctx, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(ctx, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetSitemap operation middleware
+func (sh *strictHandler) GetSitemap(ctx *gin.Context, params GetSitemapParams) {
+	var request GetSitemapRequestObject
+
+	request.Params = params
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetSitemap(ctx, request.(GetSitemapRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetSitemap")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		sh.options.HandlerErrorFunc(ctx, err)
+	} else if validResponse, ok := response.(GetSitemapResponseObject); ok {
+		if err := validResponse.VisitGetSitemapResponse(ctx.Writer); err != nil {
 			sh.options.ResponseErrorHandlerFunc(ctx, err)
 		}
 	} else if response != nil {

--- a/api/internal/api/openapi.yaml
+++ b/api/internal/api/openapi.yaml
@@ -210,6 +210,41 @@ paths:
               schema:
                 $ref: "#/components/schemas/EntryList"
 
+  /v1/sitemap:
+    get:
+      tags: [sitemap]
+      operationId: getSitemap
+      summary: 全収録語彙を熱度順にページングして取得
+      description: >
+        sitemap 生成用に、全収録語彙を熱度（人気度）の降順でページングして返す。
+        熱度 = 直近30日のアクセス数 × 2 + 直近365日のアクセス数 × 1。
+        Redis 未設定時は freq_rank → 見出し語の安定順で返し、heat は null になる。
+      parameters:
+        - name: page
+          in: query
+          required: false
+          description: ページ番号（1 始まり）
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - name: page_size
+          in: query
+          required: false
+          description: 1 ページあたりの件数
+          schema:
+            type: integer
+            default: 1000
+            minimum: 1
+            maximum: 50000
+      responses:
+        "200":
+          description: 熱度順の語彙ページ
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SitemapPage"
+
 components:
   schemas:
     Error:
@@ -486,3 +521,42 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DefinitionSearchResult"
+
+    SitemapItem:
+      type: object
+      required: [uuid, entry]
+      properties:
+        uuid:
+          type: string
+        entry:
+          type: string
+        reading_primary:
+          type: string
+          nullable: true
+        heat:
+          type: number
+          format: double
+          nullable: true
+          description: 熱度指数（2×直近30日 + 1×直近365日のアクセス数）。Redis 無効時は null
+        updated_at:
+          type: string
+          nullable: true
+          description: エントリの更新日時（sitemap の lastmod 用）
+
+    SitemapPage:
+      type: object
+      required: [page, page_size, total, total_pages, items]
+      properties:
+        page:
+          type: integer
+        page_size:
+          type: integer
+        total:
+          type: integer
+          description: 全収録語彙数
+        total_pages:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SitemapItem"

--- a/api/internal/cache/cache.go
+++ b/api/internal/cache/cache.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+
+	"github.com/Iktahana/Genji/api/internal/redisx"
 )
 
 // Cache はキャッシュの抽象。
@@ -34,7 +36,8 @@ func (NoopCache) Close() error                                      { return nil
 
 // RedisCache は Redis を使う実装。
 type RedisCache struct {
-	client *redis.Client
+	client     *redis.Client
+	ownsClient bool // true なら Close() で client を閉じる
 }
 
 func (c *RedisCache) Get(ctx context.Context, key string) ([]byte, bool) {
@@ -53,32 +56,33 @@ func (c *RedisCache) Set(ctx context.Context, key string, val []byte, ttl time.D
 
 func (c *RedisCache) Enabled() bool { return true }
 
-func (c *RedisCache) Close() error { return c.client.Close() }
+func (c *RedisCache) Close() error {
+	if c.ownsClient {
+		return c.client.Close()
+	}
+	return nil
+}
 
-// New はキャッシュを構築する。
+// New は自前で Redis に接続してキャッシュを構築する（client を所有し Close で閉じる）。
 //
-// addr が空なら NoopCache を返す。addr 指定時は接続して PING を試み、
-// 失敗した場合はエラーで落とさず NoopCache にフォールバックする。
+// addr が空、または接続失敗時はエラーで落とさず NoopCache にフォールバックする。
 func New(addr, password string, db int) Cache {
-	if addr == "" {
-		log.Println("cache: disabled (GENJI_REDIS_ADDR not set)")
+	client := redisx.Connect(addr, password, db)
+	if client == nil {
 		return NoopCache{}
 	}
+	return &RedisCache{client: client, ownsClient: true}
+}
 
-	client := redis.NewClient(&redis.Options{
-		Addr:     addr,
-		Password: password,
-		DB:       db,
-	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	if err := client.Ping(ctx).Err(); err != nil {
-		log.Printf("cache: redis ping failed (%v), falling back to disabled cache", err)
-		_ = client.Close()
+// NewWithClient は既存の共有 Redis クライアントからキャッシュを構築する。
+//
+// client が nil なら NoopCache を返す。client の Close は呼び出し側が管理する
+// （Close() は何もしない）。
+func NewWithClient(client *redis.Client) Cache {
+	if client == nil {
+		log.Println("cache: disabled (no redis client)")
 		return NoopCache{}
 	}
-
-	log.Printf("cache: enabled (redis %s db=%d)", addr, db)
-	return &RedisCache{client: client}
+	log.Println("cache: enabled")
+	return &RedisCache{client: client, ownsClient: false}
 }

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -14,23 +14,32 @@ type Config struct {
 	// Port は HTTP リッスンポート。
 	Port string
 
-	// RedisAddr が空ならキャッシュ無効（Noop）。
+	// RedisAddr が空ならキャッシュ・熱度集計とも無効（Noop）。
 	RedisAddr     string
 	RedisPassword string
 	RedisDB       int
 	// CacheTTL はキャッシュ項目の有効期限。
 	CacheTTL time.Duration
+
+	// HeatAggInterval は熱度ランキングの集計間隔。
+	HeatAggInterval time.Duration
+	// HeatW30 / HeatW365 は 30日 / 365日アクセス数の重み。
+	HeatW30  float64
+	HeatW365 float64
 }
 
 // Load は環境変数から Config を構築する。未設定の項目には既定値を使う。
 func Load() Config {
 	return Config{
-		DBPath:        getenv("GENJI_DB_PATH", "genji.db"),
-		Port:          getenv("PORT", "8080"),
-		RedisAddr:     os.Getenv("GENJI_REDIS_ADDR"),
-		RedisPassword: os.Getenv("GENJI_REDIS_PASSWORD"),
-		RedisDB:       getenvInt("GENJI_REDIS_DB", 0),
-		CacheTTL:      getenvDuration("GENJI_CACHE_TTL", time.Hour),
+		DBPath:          getenv("GENJI_DB_PATH", "genji.db"),
+		Port:            getenv("PORT", "8080"),
+		RedisAddr:       os.Getenv("GENJI_REDIS_ADDR"),
+		RedisPassword:   os.Getenv("GENJI_REDIS_PASSWORD"),
+		RedisDB:         getenvInt("GENJI_REDIS_DB", 0),
+		CacheTTL:        getenvDuration("GENJI_CACHE_TTL", time.Hour),
+		HeatAggInterval: getenvDuration("GENJI_HEAT_AGG_INTERVAL", 15*time.Minute),
+		HeatW30:         getenvFloat("GENJI_HEAT_W30", 2),
+		HeatW365:        getenvFloat("GENJI_HEAT_W365", 1),
 	}
 }
 
@@ -45,6 +54,15 @@ func getenvInt(key string, def int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
+		}
+	}
+	return def
+}
+
+func getenvFloat(key string, def float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
 		}
 	}
 	return def

--- a/api/internal/heat/heat.go
+++ b/api/internal/heat/heat.go
@@ -1,0 +1,235 @@
+// Package heat は API アクセス数に基づく語彙の熱度（人気度）を Redis で管理する。
+//
+// 日毎のアクセス数を ZSET に記録し、バックグラウンドで
+//   heat = w30 × (直近30日の総数) + w365 × (直近365日の総数)
+// を集計して全語彙のランキング ZSET（genji:heat:index）を作る。
+// Redis が無い場合は Noop（全て無効）にフォールバックする。
+package heat
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	dayKeyPrefix     = "genji:hits:day:"
+	entriesAllKey    = "genji:entries:all"
+	indexKey         = "genji:heat:index"
+	indexTmpKey      = "genji:heat:index:tmp"
+	w30TmpKey        = "genji:heat:_w30"
+	w365TmpKey       = "genji:heat:_w365"
+	visitedTmpKey    = "genji:heat:_visited"
+	seededVersionKey = "genji:heat:seeded_version"
+	aggLockKey       = "genji:heat:agg:lock"
+
+	dayKeyTTL  = 366 * 24 * time.Hour
+	aggLockTTL = 10 * time.Minute // クラッシュ時のデッドロック防止用セーフティ
+	seedBatch  = 5000
+)
+
+// Ranked は1語の熱度ランキング項目。
+type Ranked struct {
+	UUID string
+	Heat float64
+}
+
+// Service は熱度カウンタ/ランキングの抽象。
+type Service interface {
+	// Enabled は Redis 連携が有効かを返す。
+	Enabled() bool
+	// Hit は指定 uuid 群のアクセスを記録する（非同期・ベストエフォート）。
+	Hit(uuids ...string)
+	// Page はランキング ZSET から offset/limit のページを返す（heat 降順）。総件数も返す。
+	Page(ctx context.Context, offset, limit int) (items []Ranked, total int, err error)
+	// Seed は DB バージョンが変わっていれば全 uuid を 0 点で土台 ZSET に積む。
+	Seed(ctx context.Context, uuids []string, version string) error
+	// StartAggregator は集計ループを起動する（ctx 終了で停止）。
+	StartAggregator(ctx context.Context)
+}
+
+// Noop は Redis 無効時の実装。
+type Noop struct{}
+
+func (Noop) Enabled() bool                                              { return false }
+func (Noop) Hit(...string)                                              {}
+func (Noop) Page(context.Context, int, int) ([]Ranked, int, error)     { return nil, 0, nil }
+func (Noop) Seed(context.Context, []string, string) error              { return nil }
+func (Noop) StartAggregator(context.Context)                           {}
+
+// redisHeat は Redis を使う実装。
+type redisHeat struct {
+	client      *redis.Client
+	w30, w365   float64
+	aggInterval time.Duration
+}
+
+// New は Service を構築する。client が nil なら Noop を返す。
+func New(client *redis.Client, w30, w365 float64, aggInterval time.Duration) Service {
+	if client == nil {
+		return Noop{}
+	}
+	if aggInterval <= 0 {
+		aggInterval = 15 * time.Minute
+	}
+	return &redisHeat{client: client, w30: w30, w365: w365, aggInterval: aggInterval}
+}
+
+func (h *redisHeat) Enabled() bool { return true }
+
+func dayKey(t time.Time) string { return dayKeyPrefix + t.UTC().Format("20060102") }
+
+// dayKeys は now を起点に直近 n 日分の day キーを返す。
+func dayKeys(now time.Time, n int) []string {
+	keys := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		keys = append(keys, dayKey(now.AddDate(0, 0, -i)))
+	}
+	return keys
+}
+
+func (h *redisHeat) Hit(uuids ...string) {
+	if len(uuids) == 0 {
+		return
+	}
+	// 呼び出し側のスライスを共有しないようコピーする。
+	ids := make([]string, len(uuids))
+	copy(ids, uuids)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		key := dayKey(time.Now())
+		pipe := h.client.Pipeline()
+		for _, u := range ids {
+			pipe.ZIncrBy(ctx, key, 1, u)
+		}
+		pipe.Expire(ctx, key, dayKeyTTL)
+		if _, err := pipe.Exec(ctx); err != nil {
+			log.Printf("heat: hit failed: %v", err)
+		}
+	}()
+}
+
+func (h *redisHeat) Page(ctx context.Context, offset, limit int) ([]Ranked, int, error) {
+	total, err := h.client.ZCard(ctx, indexKey).Result()
+	if err != nil {
+		return nil, 0, err
+	}
+	if limit <= 0 || offset >= int(total) {
+		return nil, int(total), nil
+	}
+	zs, err := h.client.ZRevRangeWithScores(ctx, indexKey, int64(offset), int64(offset+limit-1)).Result()
+	if err != nil {
+		return nil, int(total), err
+	}
+	items := make([]Ranked, 0, len(zs))
+	for _, z := range zs {
+		uuid, _ := z.Member.(string)
+		items = append(items, Ranked{UUID: uuid, Heat: z.Score})
+	}
+	return items, int(total), nil
+}
+
+func (h *redisHeat) Seed(ctx context.Context, uuids []string, version string) error {
+	cur, err := h.client.Get(ctx, seededVersionKey).Result()
+	if err == nil && cur == version && version != "" {
+		return nil // 既に同バージョンで seed 済み
+	}
+
+	tmp := entriesAllKey + ":tmp"
+	if err := h.client.Del(ctx, tmp).Err(); err != nil {
+		return err
+	}
+	for i := 0; i < len(uuids); i += seedBatch {
+		end := i + seedBatch
+		if end > len(uuids) {
+			end = len(uuids)
+		}
+		members := make([]redis.Z, 0, end-i)
+		for _, u := range uuids[i:end] {
+			members = append(members, redis.Z{Score: 0, Member: u})
+		}
+		if err := h.client.ZAdd(ctx, tmp, members...).Err(); err != nil {
+			return err
+		}
+	}
+	if len(uuids) > 0 {
+		if err := h.client.Rename(ctx, tmp, entriesAllKey).Err(); err != nil {
+			return err
+		}
+	}
+	if err := h.client.Set(ctx, seededVersionKey, version, 0).Err(); err != nil {
+		return err
+	}
+	log.Printf("heat: seeded %d entries (version=%s)", len(uuids), version)
+	return nil
+}
+
+func (h *redisHeat) StartAggregator(ctx context.Context) {
+	go func() {
+		// 起動直後に1回集計してから定期実行する。
+		h.aggregate(ctx)
+		t := time.NewTicker(h.aggInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				h.aggregate(ctx)
+			}
+		}
+	}()
+}
+
+// aggregate は day バケットを集計して genji:heat:index を再構築する。
+func (h *redisHeat) aggregate(ctx context.Context) {
+	// 多重インスタンスでの重複集計を防ぐロック（終了時に解放）。
+	ok, err := h.client.SetNX(ctx, aggLockKey, "1", aggLockTTL).Result()
+	if err != nil {
+		log.Printf("heat: agg lock error: %v", err)
+		return
+	}
+	if !ok {
+		return // 他インスタンスが集計中
+	}
+	defer h.client.Del(context.Background(), aggLockKey)
+
+	now := time.Now().UTC()
+	if err := h.client.ZUnionStore(ctx, w30TmpKey, &redis.ZStore{Keys: dayKeys(now, 30)}).Err(); err != nil {
+		log.Printf("heat: agg w30 failed: %v", err)
+		return
+	}
+	if err := h.client.ZUnionStore(ctx, w365TmpKey, &redis.ZStore{Keys: dayKeys(now, 365)}).Err(); err != nil {
+		log.Printf("heat: agg w365 failed: %v", err)
+		return
+	}
+	// heat = w30 × c30 + w365 × c365
+	if err := h.client.ZUnionStore(ctx, visitedTmpKey, &redis.ZStore{
+		Keys:    []string{w30TmpKey, w365TmpKey},
+		Weights: []float64{h.w30, h.w365},
+	}).Err(); err != nil {
+		log.Printf("heat: agg visited failed: %v", err)
+		return
+	}
+	// 全 uuid（土台 0 点）に訪問分を重ねる → 未訪問=0, 訪問=heat
+	if err := h.client.ZUnionStore(ctx, indexTmpKey, &redis.ZStore{
+		Keys:    []string{entriesAllKey, visitedTmpKey},
+		Weights: []float64{0, 1},
+	}).Err(); err != nil {
+		log.Printf("heat: agg index failed: %v", err)
+		return
+	}
+
+	// 原子的に差し替え。idxTmp が空（土台未 seed）なら index を空にする。
+	if exists, _ := h.client.Exists(ctx, indexTmpKey).Result(); exists == 1 {
+		if err := h.client.Rename(ctx, indexTmpKey, indexKey).Err(); err != nil {
+			log.Printf("heat: agg rename failed: %v", err)
+		}
+	} else {
+		h.client.Del(ctx, indexKey)
+	}
+	h.client.Del(ctx, w30TmpKey, w365TmpKey, visitedTmpKey)
+}

--- a/api/internal/heat/heat_test.go
+++ b/api/internal/heat/heat_test.go
@@ -1,0 +1,153 @@
+package heat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newTestHeat(t *testing.T) (*redisHeat, *miniredis.Miniredis) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { client.Close() })
+	return &redisHeat{client: client, w30: 2, w365: 1, aggInterval: time.Minute}, mr
+}
+
+func TestNewNilClientIsNoop(t *testing.T) {
+	s := New(nil, 2, 1, time.Minute)
+	if s.Enabled() {
+		t.Fatal("nil client should yield disabled heat service")
+	}
+	items, total, err := s.Page(context.Background(), 0, 10)
+	if err != nil || total != 0 || items != nil {
+		t.Errorf("Noop.Page = %v,%d,%v", items, total, err)
+	}
+}
+
+func TestSeedPopulatesAllAtZero(t *testing.T) {
+	h, _ := newTestHeat(t)
+	ctx := context.Background()
+	if err := h.Seed(ctx, []string{"a", "b", "c"}, "v1"); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	n, _ := h.client.ZCard(ctx, entriesAllKey).Result()
+	if n != 3 {
+		t.Errorf("entries:all card = %d, want 3", n)
+	}
+	// 同バージョンの再 seed はスキップされる（変更なし）。
+	if err := h.Seed(ctx, []string{"a"}, "v1"); err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+	if n, _ := h.client.ZCard(ctx, entriesAllKey).Result(); n != 3 {
+		t.Errorf("entries:all card after same-version reseed = %d, want 3", n)
+	}
+}
+
+func TestAggregateWeightsAndOrder(t *testing.T) {
+	h, _ := newTestHeat(t)
+	ctx := context.Background()
+
+	// d は seed されるが訪問なし（heat 0）。
+	if err := h.Seed(ctx, []string{"a", "b", "c", "d"}, "v1"); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+
+	now := time.Now().UTC()
+	today := dayKey(now)
+	old := dayKey(now.AddDate(0, 0, -100)) // 直近30日外・365日内
+
+	// a: 直近30日に3回 → c30=3, c365=3 → heat=2*3+1*3=9
+	h.client.ZIncrBy(ctx, today, 3, "a")
+	// b: 直近30日に1回 → heat=2*1+1*1=3
+	h.client.ZIncrBy(ctx, today, 1, "b")
+	// c: 100日前に5回（30日外） → c30=0, c365=5 → heat=5
+	h.client.ZIncrBy(ctx, old, 5, "c")
+
+	h.aggregate(ctx)
+
+	want := map[string]float64{"a": 9, "b": 3, "c": 5, "d": 0}
+	for uuid, exp := range want {
+		got, err := h.client.ZScore(ctx, indexKey, uuid).Result()
+		if err != nil {
+			t.Fatalf("ZScore %s: %v", uuid, err)
+		}
+		if got != exp {
+			t.Errorf("heat[%s] = %v, want %v", uuid, got, exp)
+		}
+	}
+
+	// Page は heat 降順: a(9), c(5), b(3), d(0)
+	items, total, err := h.Page(ctx, 0, 10)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	if total != 4 {
+		t.Errorf("total = %d, want 4", total)
+	}
+	wantOrder := []string{"a", "c", "b", "d"}
+	if len(items) != 4 {
+		t.Fatalf("got %d items, want 4", len(items))
+	}
+	for i, w := range wantOrder {
+		if items[i].UUID != w {
+			t.Errorf("items[%d] = %s, want %s (full: %+v)", i, items[i].UUID, w, items)
+		}
+	}
+	if items[0].Heat != 9 {
+		t.Errorf("top heat = %v, want 9", items[0].Heat)
+	}
+}
+
+func TestPagePagination(t *testing.T) {
+	h, _ := newTestHeat(t)
+	ctx := context.Background()
+	h.Seed(ctx, []string{"a", "b", "c", "d"}, "v1")
+	h.client.ZIncrBy(ctx, dayKey(time.Now().UTC()), 10, "a")
+	h.aggregate(ctx)
+
+	// 2件目から2件 → c, b（a が先頭なので offset=1 で c,b）
+	items, total, err := h.Page(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	if total != 4 {
+		t.Errorf("total = %d, want 4", total)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+}
+
+func TestHitIncrementsDayKey(t *testing.T) {
+	h, mr := newTestHeat(t)
+	h.Hit("x", "y", "x")
+
+	// Hit は非同期なので少し待ってから確認する。
+	today := dayKey(time.Now().UTC())
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if mr.Exists(today) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	ctx := context.Background()
+	if score, _ := h.client.ZScore(ctx, today, "x").Result(); score != 2 {
+		t.Errorf("hit count for x = %v, want 2", score)
+	}
+	if score, _ := h.client.ZScore(ctx, today, "y").Result(); score != 1 {
+		t.Errorf("hit count for y = %v, want 1", score)
+	}
+	// TTL が設定されていること。
+	if ttl := mr.TTL(today); ttl <= 0 {
+		t.Errorf("day key TTL not set: %v", ttl)
+	}
+}

--- a/api/internal/redisx/redisx.go
+++ b/api/internal/redisx/redisx.go
@@ -1,0 +1,35 @@
+// Package redisx は Redis クライアントの接続ヘルパーを提供する。
+//
+// 接続先が未指定、または疎通に失敗した場合は nil を返す（エラーで落とさない）。
+// 呼び出し側はこの単一クライアントを cache と heat で共有し、自身で Close する。
+package redisx
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Connect は Redis に接続する。addr が空、または PING 失敗時は nil を返す。
+func Connect(addr, password string, db int) *redis.Client {
+	if addr == "" {
+		log.Println("redis: disabled (GENJI_REDIS_ADDR not set)")
+		return nil
+	}
+	client := redis.NewClient(&redis.Options{
+		Addr:     addr,
+		Password: password,
+		DB:       db,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		log.Printf("redis: ping failed (%v), running without redis", err)
+		_ = client.Close()
+		return nil
+	}
+	log.Printf("redis: connected (%s db=%d)", addr, db)
+	return client
+}

--- a/api/internal/server/handlers.go
+++ b/api/internal/server/handlers.go
@@ -5,23 +5,26 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"time"
 
 	"github.com/Iktahana/Genji/api/internal/api"
 	"github.com/Iktahana/Genji/api/internal/cache"
+	"github.com/Iktahana/Genji/api/internal/heat"
 	"github.com/Iktahana/Genji/api/internal/store"
 )
 
-// Handler は StrictServerInterface の実装。store と cache を保持する。
+// Handler は StrictServerInterface の実装。store・cache・heat を保持する。
 type Handler struct {
 	store *store.Store
 	cache cache.Cache
+	heat  heat.Service
 	ttl   time.Duration
 }
 
 // NewHandler は Handler を生成する。
-func NewHandler(s *store.Store, c cache.Cache, ttl time.Duration) *Handler {
-	return &Handler{store: s, cache: c, ttl: ttl}
+func NewHandler(s *store.Store, c cache.Cache, h heat.Service, ttl time.Duration) *Handler {
+	return &Handler{store: s, cache: c, heat: h, ttl: ttl}
 }
 
 // 確実に StrictServerInterface を満たすことをコンパイル時に保証する。
@@ -79,6 +82,7 @@ func (h *Handler) GetEntryByUUID(ctx context.Context, request api.GetEntryByUUID
 	if err != nil {
 		return nil, err
 	}
+	h.heat.Hit(e.Uuid)
 	return api.GetEntryByUUID200JSONResponse(e), nil
 }
 
@@ -94,6 +98,7 @@ func (h *Handler) LookupByEntry(ctx context.Context, request api.LookupByEntryRe
 	if err != nil {
 		return nil, err
 	}
+	h.heat.Hit(entryUUIDs(list.Entries)...)
 	return api.LookupByEntry200JSONResponse(list), nil
 }
 
@@ -109,6 +114,7 @@ func (h *Handler) LookupByReading(ctx context.Context, request api.LookupByReadi
 	if err != nil {
 		return nil, err
 	}
+	h.heat.Hit(entryUUIDs(list.Entries)...)
 	return api.LookupByReading200JSONResponse(list), nil
 }
 
@@ -156,6 +162,106 @@ func (h *Handler) RandomEntries(_ context.Context, request api.RandomEntriesRequ
 		return nil, err
 	}
 	return api.RandomEntries200JSONResponse(api.EntryList{Count: len(entries), Entries: entries}), nil
+}
+
+// GetSitemap は全収録語彙を熱度降順でページングして返す。
+// Redis 有効時は heat ランキング、無効時は freq_rank→見出し語の安定順（heat=null）。
+func (h *Handler) GetSitemap(ctx context.Context, request api.GetSitemapRequestObject) (api.GetSitemapResponseObject, error) {
+	page := clamp(request.Params.Page, 1, 1, math.MaxInt32)
+	size := clamp(request.Params.PageSize, 1000, 1, 50000)
+	offset := (page - 1) * size
+
+	// heat はゆっくり更新されるため、ページ結果は短 TTL でキャッシュする。
+	key := "genji:v1:sitemap:" + itoa(size) + ":" + itoa(page)
+	out, err := cached(ctx, h, key, func() (api.SitemapPage, error) {
+		return h.buildSitemap(ctx, page, size, offset)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return api.GetSitemap200JSONResponse(out), nil
+}
+
+func (h *Handler) buildSitemap(ctx context.Context, page, size, offset int) (api.SitemapPage, error) {
+	var (
+		items []api.SitemapItem
+		total int
+	)
+
+	if h.heat.Enabled() {
+		ranked, t, err := h.heat.Page(ctx, offset, size)
+		if err != nil {
+			return api.SitemapPage{}, err
+		}
+		total = t
+		uuids := make([]string, len(ranked))
+		for i, r := range ranked {
+			uuids[i] = r.UUID
+		}
+		rows, err := h.store.SitemapByUUIDs(uuids)
+		if err != nil {
+			return api.SitemapPage{}, err
+		}
+		// ランキングの順序を維持して組み立てる。
+		items = make([]api.SitemapItem, 0, len(ranked))
+		for _, r := range ranked {
+			row, ok := rows[r.UUID]
+			if !ok {
+				continue // DB に無い uuid（バージョン差異等）はスキップ
+			}
+			heatVal := r.Heat
+			items = append(items, api.SitemapItem{
+				Uuid:           row.UUID,
+				Entry:          row.Entry,
+				ReadingPrimary: row.ReadingPrimary,
+				UpdatedAt:      row.UpdatedAt,
+				Heat:           &heatVal,
+			})
+		}
+	} else {
+		t, err := h.store.CountEntries()
+		if err != nil {
+			return api.SitemapPage{}, err
+		}
+		total = t
+		rows, err := h.store.SitemapByFreq(size, offset)
+		if err != nil {
+			return api.SitemapPage{}, err
+		}
+		items = make([]api.SitemapItem, 0, len(rows))
+		for _, row := range rows {
+			items = append(items, api.SitemapItem{
+				Uuid:           row.UUID,
+				Entry:          row.Entry,
+				ReadingPrimary: row.ReadingPrimary,
+				UpdatedAt:      row.UpdatedAt,
+				Heat:           nil,
+			})
+		}
+	}
+
+	totalPages := 0
+	if size > 0 {
+		totalPages = (total + size - 1) / size
+	}
+	return api.SitemapPage{
+		Page:       page,
+		PageSize:   size,
+		Total:      total,
+		TotalPages: totalPages,
+		Items:      items,
+	}, nil
+}
+
+// entryUUIDs は entry スライスから uuid を抽出する（heat カウント用）。
+func entryUUIDs(entries []api.Entry) []string {
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.Uuid != "" {
+			ids = append(ids, e.Uuid)
+		}
+	}
+	return ids
 }
 
 // clamp は *int の値を [min, max] に収める。nil なら def を使う。

--- a/api/internal/server/handlers_test.go
+++ b/api/internal/server/handlers_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Iktahana/Genji/api/internal/api"
 	"github.com/Iktahana/Genji/api/internal/cache"
+	"github.com/Iktahana/Genji/api/internal/heat"
 	"github.com/Iktahana/Genji/api/internal/store"
 )
 
@@ -101,8 +102,13 @@ func buildTestDB(t *testing.T) string {
 	return path
 }
 
-// newTestServer はテスト用の gin router と memCache を返す。
+// newTestServer はテスト用の gin router を返す（heat 無効）。
 func newTestServer(t *testing.T, c cache.Cache) *gin.Engine {
+	return newTestServerWithHeat(t, c, heat.Noop{})
+}
+
+// newTestServerWithHeat は heat サービスを指定してテスト用 router を返す。
+func newTestServerWithHeat(t *testing.T, c cache.Cache, hsvc heat.Service) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -112,7 +118,7 @@ func newTestServer(t *testing.T, c cache.Cache) *gin.Engine {
 	}
 	t.Cleanup(func() { st.Close() })
 
-	h := NewHandler(st, c, time.Minute)
+	h := NewHandler(st, c, hsvc, time.Minute)
 	r := gin.New()
 	api.RegisterDocs(r)
 	api.RegisterHandlers(r, api.NewStrictHandler(h, nil))
@@ -356,3 +362,83 @@ func TestClamp(t *testing.T) {
 }
 
 func ptr(n int) *int { return &n }
+
+// fakeHeat は sitemap テスト用の制御可能な heat.Service。
+type fakeHeat struct {
+	ranked []heat.Ranked
+	total  int
+}
+
+func (fakeHeat) Enabled() bool   { return true }
+func (fakeHeat) Hit(...string)   {}
+func (fakeHeat) Seed(context.Context, []string, string) error { return nil }
+func (fakeHeat) StartAggregator(context.Context)              {}
+func (f fakeHeat) Page(_ context.Context, offset, limit int) ([]heat.Ranked, int, error) {
+	if offset >= len(f.ranked) {
+		return nil, f.total, nil
+	}
+	end := offset + limit
+	if end > len(f.ranked) {
+		end = len(f.ranked)
+	}
+	return f.ranked[offset:end], f.total, nil
+}
+
+const testUUID = "u1" // server テスト DB の sampleRawJSON が持つ uuid
+
+func TestSitemapWithHeat(t *testing.T) {
+	fh := fakeHeat{ranked: []heat.Ranked{{UUID: testUUID, Heat: 9}}, total: 1}
+	r := newTestServerWithHeat(t, cache.NoopCache{}, fh)
+
+	w := doGet(t, r, "/v1/sitemap?page=1&page_size=50")
+	if w.Code != 200 {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var p api.SitemapPage
+	if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if p.Total != 1 || p.Page != 1 || p.PageSize != 50 || p.TotalPages != 1 {
+		t.Errorf("pagination = %+v", p)
+	}
+	if len(p.Items) != 1 {
+		t.Fatalf("got %d items, want 1", len(p.Items))
+	}
+	if p.Items[0].Entry != "雪" {
+		t.Errorf("entry = %q, want 雪", p.Items[0].Entry)
+	}
+	if p.Items[0].Heat == nil || *p.Items[0].Heat != 9 {
+		t.Errorf("heat = %v, want 9", p.Items[0].Heat)
+	}
+}
+
+func TestSitemapFallbackWithoutRedis(t *testing.T) {
+	// heat 無効（Noop）→ DB 順フォールバック、heat=null
+	r := newTestServerWithHeat(t, cache.NoopCache{}, heat.Noop{})
+	w := doGet(t, r, "/v1/sitemap?page=1&page_size=50")
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var p api.SitemapPage
+	json.Unmarshal(w.Body.Bytes(), &p)
+	if p.Total != 1 || len(p.Items) != 1 {
+		t.Fatalf("page = %+v", p)
+	}
+	if p.Items[0].Entry != "雪" {
+		t.Errorf("entry = %q, want 雪", p.Items[0].Entry)
+	}
+	if p.Items[0].Heat != nil {
+		t.Errorf("heat should be null without redis, got %v", *p.Items[0].Heat)
+	}
+}
+
+func TestSitemapPaginationDefaults(t *testing.T) {
+	r := newTestServerWithHeat(t, cache.NoopCache{}, heat.Noop{})
+	// page/page_size 省略 → 既定 page=1, page_size=1000
+	w := doGet(t, r, "/v1/sitemap")
+	var p api.SitemapPage
+	json.Unmarshal(w.Body.Bytes(), &p)
+	if p.Page != 1 || p.PageSize != 1000 {
+		t.Errorf("defaults = page %d size %d, want 1/1000", p.Page, p.PageSize)
+	}
+}

--- a/api/internal/store/store.go
+++ b/api/internal/store/store.go
@@ -271,3 +271,113 @@ func sanitizeFTS(q string) string {
 	}
 	return strings.Join(quoted, " ")
 }
+
+// SitemapRow は sitemap 用の軽量な語彙行。Heat は呼び出し側（heat 連携）で設定する。
+type SitemapRow struct {
+	UUID           string
+	Entry          string
+	ReadingPrimary *string
+	UpdatedAt      *string
+	Heat           *float64
+}
+
+// CountEntries は収録語彙の総数を返す。
+func (s *Store) CountEntries() (int, error) {
+	var n int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM entries`).Scan(&n)
+	return n, err
+}
+
+// AllUUIDs は全エントリの uuid を返す（heat ランキングの土台 seed 用）。
+func (s *Store) AllUUIDs() ([]string, error) {
+	rows, err := s.db.Query(`SELECT uuid FROM entries`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	uuids := make([]string, 0, 1024)
+	for rows.Next() {
+		var u string
+		if err := rows.Scan(&u); err != nil {
+			return nil, err
+		}
+		uuids = append(uuids, u)
+	}
+	return uuids, rows.Err()
+}
+
+// SitemapByUUIDs は指定 uuid 群の sitemap 行を取得する（順序は呼び出し側で復元する）。
+func (s *Store) SitemapByUUIDs(uuids []string) (map[string]SitemapRow, error) {
+	out := make(map[string]SitemapRow, len(uuids))
+	if len(uuids) == 0 {
+		return out, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(uuids)), ",")
+	args := make([]any, len(uuids))
+	for i, u := range uuids {
+		args[i] = u
+	}
+	query := `SELECT uuid, entry, reading_primary, json_extract(meta, '$.updated_at')
+	          FROM entries WHERE uuid IN (` + placeholders + `)`
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			r       SitemapRow
+			reading sql.NullString
+			updated sql.NullString
+		)
+		if err := rows.Scan(&r.UUID, &r.Entry, &reading, &updated); err != nil {
+			return nil, err
+		}
+		if reading.Valid {
+			r.ReadingPrimary = &reading.String
+		}
+		if updated.Valid {
+			r.UpdatedAt = &updated.String
+		}
+		out[r.UUID] = r
+	}
+	return out, rows.Err()
+}
+
+// SitemapByFreq は Redis 無効時のフォールバック。freq_rank 昇順（無いものは後ろ）→ 見出し語順で返す。
+func (s *Store) SitemapByFreq(limit, offset int) ([]SitemapRow, error) {
+	rows, err := s.db.Query(`
+		SELECT uuid, entry, reading_primary,
+		       json_extract(meta, '$.updated_at') AS updated_at,
+		       CAST(json_extract(meta, '$.freq_rank') AS INTEGER) AS freq
+		FROM entries
+		ORDER BY (freq IS NULL), freq ASC, entry ASC
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]SitemapRow, 0, limit)
+	for rows.Next() {
+		var (
+			r       SitemapRow
+			reading sql.NullString
+			updated sql.NullString
+			freq    sql.NullInt64
+		)
+		if err := rows.Scan(&r.UUID, &r.Entry, &reading, &updated, &freq); err != nil {
+			return nil, err
+		}
+		if reading.Valid {
+			r.ReadingPrimary = &reading.String
+		}
+		if updated.Valid {
+			r.UpdatedAt = &updated.String
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/api/internal/store/store_test.go
+++ b/api/internal/store/store_test.go
@@ -203,3 +203,71 @@ func TestSanitizeFTS(t *testing.T) {
 		}
 	}
 }
+
+func TestCountEntries(t *testing.T) {
+	s := openTestStore(t)
+	n, err := s.CountEntries()
+	if err != nil {
+		t.Fatalf("CountEntries: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count = %d, want 1", n)
+	}
+}
+
+func TestAllUUIDs(t *testing.T) {
+	s := openTestStore(t)
+	uuids, err := s.AllUUIDs()
+	if err != nil {
+		t.Fatalf("AllUUIDs: %v", err)
+	}
+	if len(uuids) != 1 || uuids[0] != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("uuids = %v", uuids)
+	}
+}
+
+func TestSitemapByUUIDs(t *testing.T) {
+	s := openTestStore(t)
+	const id = "11111111-1111-1111-1111-111111111111"
+	rows, err := s.SitemapByUUIDs([]string{id, "missing"})
+	if err != nil {
+		t.Fatalf("SitemapByUUIDs: %v", err)
+	}
+	row, ok := rows[id]
+	if !ok {
+		t.Fatalf("uuid %s not found in result", id)
+	}
+	if row.Entry != "雪" {
+		t.Errorf("entry = %q, want 雪", row.Entry)
+	}
+	if _, ok := rows["missing"]; ok {
+		t.Error("missing uuid should not be present")
+	}
+	// 空入力は空 map を返す。
+	empty, err := s.SitemapByUUIDs(nil)
+	if err != nil || len(empty) != 0 {
+		t.Errorf("empty input: %v, %v", empty, err)
+	}
+}
+
+func TestSitemapByFreq(t *testing.T) {
+	s := openTestStore(t)
+	rows, err := s.SitemapByFreq(10, 0)
+	if err != nil {
+		t.Fatalf("SitemapByFreq: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].Entry != "雪" {
+		t.Errorf("entry = %q, want 雪", rows[0].Entry)
+	}
+	if rows[0].Heat != nil {
+		t.Errorf("heat should be nil in fallback, got %v", rows[0].Heat)
+	}
+	// offset で範囲外 → 0 件。
+	rows2, _ := s.SitemapByFreq(10, 5)
+	if len(rows2) != 0 {
+		t.Errorf("offset beyond range should be empty, got %d", len(rows2))
+	}
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -210,6 +210,41 @@ paths:
               schema:
                 $ref: "#/components/schemas/EntryList"
 
+  /v1/sitemap:
+    get:
+      tags: [sitemap]
+      operationId: getSitemap
+      summary: 全収録語彙を熱度順にページングして取得
+      description: >
+        sitemap 生成用に、全収録語彙を熱度（人気度）の降順でページングして返す。
+        熱度 = 直近30日のアクセス数 × 2 + 直近365日のアクセス数 × 1。
+        Redis 未設定時は freq_rank → 見出し語の安定順で返し、heat は null になる。
+      parameters:
+        - name: page
+          in: query
+          required: false
+          description: ページ番号（1 始まり）
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - name: page_size
+          in: query
+          required: false
+          description: 1 ページあたりの件数
+          schema:
+            type: integer
+            default: 1000
+            minimum: 1
+            maximum: 50000
+      responses:
+        "200":
+          description: 熱度順の語彙ページ
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SitemapPage"
+
 components:
   schemas:
     Error:
@@ -486,3 +521,42 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DefinitionSearchResult"
+
+    SitemapItem:
+      type: object
+      required: [uuid, entry]
+      properties:
+        uuid:
+          type: string
+        entry:
+          type: string
+        reading_primary:
+          type: string
+          nullable: true
+        heat:
+          type: number
+          format: double
+          nullable: true
+          description: 熱度指数（2×直近30日 + 1×直近365日のアクセス数）。Redis 無効時は null
+        updated_at:
+          type: string
+          nullable: true
+          description: エントリの更新日時（sitemap の lastmod 用）
+
+    SitemapPage:
+      type: object
+      required: [page, page_size, total, total_pages, items]
+      properties:
+        page:
+          type: integer
+        page_size:
+          type: integer
+        total:
+          type: integer
+          description: 全収録語彙数
+        total_pages:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SitemapItem"


### PR DESCRIPTION
## Summary

前端（`https://dict.illusions.app`）の sitemap 生成用に、**全収録語彙を熱度（人気度）順でページング返却する** `GET /v1/sitemap` を追加します。熱度は API アクセス数を Redis でカウントして算出します。

- `heat = 2 × (直近30日のアクセス数) + 1 × (直近365日のアクセス数)`（365日窓は30日窓を含む）
- 各 sitemap 項目が `heat` 指数・`updated_at`（lastmod 用）を返す
- **Redis は任意**：未設定・接続失敗時は `freq_rank → 見出し語` の DB 安定順にフォールバック（`heat=null`）。エンドポイントは常に動作

## エンドポイント

`GET /v1/sitemap?page=1&page_size=1000`（`page_size` 上限 50000）→ `{ page, page_size, total, total_pages, items[] }`

## アクセス計上（熱度カウント）

`/v1/entries/{uuid}` / `/v1/lookup/entry` / `/v1/lookup/reading` で返った各 uuid を非同期・ベストエフォートでカウント（検索は対象外）。

## Changes

| 領域 | 内容 |
|---|---|
| `api/openapi.yaml` | `/v1/sitemap` + `SitemapItem`/`SitemapPage` 追加（再生成済み） |
| `api/internal/heat`（新規） | 日次 ZSET 集計 → `genji:heat:index` ランキング。起動時 seed + バックグラウンド集計（`GENJI_HEAT_AGG_INTERVAL` 既定15分）、多重実行ロック、Noop フォールバック |
| `api/internal/redisx`（新規） | 共有 Redis クライアント接続ヘルパー（cache と heat で共用） |
| `api/internal/cache` | `NewWithClient(*redis.Client)` を追加。client 所有権を main に集約 |
| `api/internal/store` | `AllUUIDs`/`CountEntries`/`SitemapByUUIDs`/`SitemapByFreq` を追加 |
| `api/internal/config` | `GENJI_HEAT_AGG_INTERVAL`/`GENJI_HEAT_W30`/`GENJI_HEAT_W365` を追加 |
| `api/internal/server` | lookup×2・get-by-uuid に `heat.Hit`、`Sitemap` ハンドラ（Redis/フォールバック分岐） |
| `api/cmd/genji-api/main.go` | Redis client を一度生成→cache/heat 共有、起動時 seed + 集計ループ起動 |
| docs | `api/README.md` に熱度ランキング節、root `README.md` にエンドポイント追記 |

## Test plan

- [x] `make generate` / `go build -tags sqlite_fts5 ./...` / `go vet`
- [x] `go test -tags sqlite_fts5 ./...`（全パッケージ green）
  - heat（miniredis）: 重み付け `2×c30+1×c365`、heat 降順、seed、Hit カウント、TTL
  - store: `SitemapByUUIDs`/`SitemapByFreq`/`CountEntries`/`AllUUIDs`
  - server: `/v1/sitemap` を heat 有り（fake）/無し（DB 順・heat=null）の両方 + ページング
- [x] 手動 E2E（Redis 無し・小 DB）: `/v1/sitemap` が `freq_rank` 順（花→雪→月）・`total`/`total_pages` 正常・`heat` 省略を確認
- [ ] 本番（Redis 有り）で lookup を叩いた語が集計後に上位へ来ることを確認

> ℹ️ メモリ目安: `genji:entries:all` + `genji:heat:index` で約 215k×2 メンバー（数十 MB）。日次 ZSET は 366日で自然失効。

🤖 Generated with [Claude Code](https://claude.com/claude-code)