### PR TITLE
feat(freq): 辞典エントリに青空文庫頻度 meta.frequencies を追加

### DIFF
--- a/api/internal/api/genji.gen.go
+++ b/api/internal/api/genji.gen.go
@@ -71,9 +71,14 @@ type EntryList struct {
 
 // EntryMeta defines model for EntryMeta.
 type EntryMeta struct {
-	Source    *string `json:"source,omitempty"`
-	UpdatedAt *string `json:"updated_at,omitempty"`
-	Version   *string `json:"version,omitempty"`
+	// FreqRank 頻度ランク（小さいほど高頻度。hingston/japanese 由来）
+	FreqRank *int `json:"freq_rank,omitempty"`
+
+	// Frequencies 出典別の総出現回数。例: {"aozora": 1234}
+	Frequencies *map[string]int `json:"frequencies,omitempty"`
+	Source      *string         `json:"source,omitempty"`
+	UpdatedAt   *string         `json:"updated_at,omitempty"`
+	Version     *string         `json:"version,omitempty"`
 }
 
 // Error defines model for Error.

--- a/api/internal/api/openapi.yaml
+++ b/api/internal/api/openapi.yaml
@@ -389,6 +389,15 @@ components:
           type: string
         updated_at:
           type: string
+        freq_rank:
+          type: integer
+          nullable: true
+          description: "頻度ランク（小さいほど高頻度。hingston/japanese 由来）"
+        frequencies:
+          type: object
+          additionalProperties:
+            type: integer
+          description: '出典別の総出現回数。例: {"aozora": 1234}'
 
     Entry:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -389,6 +389,15 @@ components:
           type: string
         updated_at:
           type: string
+        freq_rank:
+          type: integer
+          nullable: true
+          description: "頻度ランク（小さいほど高頻度。hingston/japanese 由来）"
+        frequencies:
+          type: object
+          additionalProperties:
+            type: integer
+          description: '出典別の総出現回数。例: {"aozora": 1234}'
 
     Entry:
       type: object

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# Genji 辞典データ生成スクリプト（script/build_dictionary.py）の依存。
+# 注意: これらはローカルでのデータ再生成にのみ必要。
+# CI（json_to_sqlite.py）はコミット済み JSON を使うため不要。
+
+# 青空文庫コーパスの形態素解析による頻度カウント用
+sudachipy>=0.6.8
+sudachidict_core>=20230927

--- a/script/backfill_frequency.py
+++ b/script/backfill_frequency.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+既存の data/**/*.json に「出典別の総出現回数」(meta.frequencies) を
+in-place で注入するバックフィルスクリプト。
+
+build_dictionary.py をフル再実行すると後付けの enrich（AI 生成例文など）が
+失われるため、頻度フィールドだけを既存 JSON に追記する用途で使う。
+
+頻度テーブルの供給は 2 通り:
+  1) --freq-table aozora_freq.json.gz を渡す（事前生成済み・軽量。Aozora/Sudachi 不要）
+  2) 省略時は build_dictionary.build_corpus_frequency で青空文庫を解析して生成
+     （リポジトリ clone 済み aozora ディレクトリと sudachipy が必要・重い）
+
+使用例:
+    # 重い解析を別環境で済ませてテーブルだけ持ち込む場合
+    python3 script/backfill_frequency.py --freq-table /tmp/aozora_freq.json.gz
+
+    # その場で青空文庫から生成して注入する場合
+    python3 script/backfill_frequency.py --aozora-dir /tmp/aozorabunko_text --workers 8
+
+    # 中身を変えずに件数だけ確認
+    python3 script/backfill_frequency.py --freq-table /tmp/aozora_freq.json.gz --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+# build_dictionary.py を同じディレクトリからインポート
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import build_dictionary as bd  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("backfill_frequency")
+
+
+def load_freq_table(path: Path) -> dict[str, int]:
+    """事前生成済みの頻度テーブル（gzip JSON: {word: count}）を読み込む。"""
+    opener = gzip.open if path.suffix == ".gz" else open
+    with opener(path, "rt", encoding="utf-8") as f:
+        data = json.load(f)
+    return {str(k): int(v) for k, v in data.items()}
+
+
+def backfill_file(
+    file_path: Path,
+    freq_counts: dict[str, int],
+    source: str,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """
+    1 ファイル（エントリ配列）の meta.frequencies[source] を更新する。
+    Returns: (このファイルで頻度を持つエントリ数, 値が変化したエントリ数)
+    """
+    try:
+        with file_path.open(encoding="utf-8") as f:
+            entries = json.load(f)
+    except Exception as exc:
+        log.warning("読み込み失敗（スキップ）: %s (%s)", file_path, exc)
+        return 0, 0
+
+    if not isinstance(entries, list):
+        return 0, 0
+
+    have = 0
+    changed = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        word = entry.get("entry")
+        count = freq_counts.get(word, 0) if word else 0
+        meta = entry.setdefault("meta", {})
+        freqs = meta.get("frequencies")
+        if not isinstance(freqs, dict):
+            freqs = {}
+
+        old = freqs.get(source)
+        if count > 0:
+            if old != count:
+                freqs[source] = count
+                changed += 1
+            have += 1
+        else:
+            # 0 件は疎フィールド維持のためキーを除去
+            if source in freqs:
+                del freqs[source]
+                changed += 1
+
+        if freqs:
+            meta["frequencies"] = freqs
+        elif "frequencies" in meta:
+            del meta["frequencies"]
+
+    if changed and not dry_run:
+        # 既存 data/ JSON の形式（indent=2・末尾改行なし）に厳密一致させ、
+        # 実行時に整形差分が出ないようにする
+        tmp_path = file_path.with_suffix(".json.tmp")
+        with tmp_path.open("w", encoding="utf-8") as f:
+            json.dump(entries, f, ensure_ascii=False, indent=2)
+        tmp_path.rename(file_path)
+
+    return have, changed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="既存 data/ JSON に meta.frequencies を in-place 注入する",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--data-dir",   default=_REPO_ROOT / "data", type=Path,
+                        help="辞典 JSON のルートディレクトリ")
+    parser.add_argument("--source",     default="aozora",
+                        help="頻度の出典名（meta.frequencies のキー）")
+    parser.add_argument("--freq-table", default=None, type=Path,
+                        help="事前生成済み頻度テーブル（gzip JSON）。指定時はこれを使い再解析しない")
+    parser.add_argument("--aozora-dir", default=Path("/tmp/aozorabunko_text"), type=Path,
+                        help="青空文庫テキストのルート（--freq-table 未指定時に解析）")
+    parser.add_argument("--tmp-dir",    default=Path("/tmp"), type=Path,
+                        help="チェックポイント／生成テーブルの保存先")
+    parser.add_argument("--workers",    default=None, type=int,
+                        help="解析の並列数（省略時: CPU コア数）")
+    parser.add_argument("--resume",     action="store_true",
+                        help="頻度カウントを前回チェックポイントから再開")
+    parser.add_argument("--dry-run",    action="store_true",
+                        help="ファイルを書き換えず件数のみ表示")
+    args = parser.parse_args()
+
+    start = time.perf_counter()
+
+    # ── 頻度テーブルの用意 ─────────────────────────────────
+    if args.freq_table:
+        if not args.freq_table.exists():
+            log.error("頻度テーブルが見つかりません: %s", args.freq_table)
+            sys.exit(1)
+        bd.Progress.group(f"頻度テーブル読み込み: {args.freq_table}")
+        freq_counts = load_freq_table(args.freq_table)
+        bd.Progress.ok(f"{len(freq_counts):,} 語")
+        bd.Progress.endgroup()
+    else:
+        n_workers = args.workers or (os.cpu_count() or 4)
+        freq_counts = bd.build_corpus_frequency(
+            args.aozora_dir,
+            n_workers=n_workers,
+            checkpoint_path=args.tmp_dir / bd._FREQ_CHECKPOINT_NAME,
+            table_path=args.tmp_dir / bd._FREQ_TABLE_NAME,
+            resume=args.resume,
+        )
+
+    if not freq_counts:
+        log.error("頻度テーブルが空です。中止します。")
+        sys.exit(1)
+
+    # ── data/ への注入 ─────────────────────────────────────
+    bd.Progress.group(f"data/ への {args.source} 頻度注入  (dry_run={args.dry_run})")
+    files = sorted(args.data_dir.rglob("*.json"))
+    bd.Progress.step(f"対象ファイル: {len(files):,}")
+
+    total_files_touched = 0
+    total_entries_have  = 0
+    total_changed       = 0
+    last_report = time.perf_counter()
+
+    for i, fp in enumerate(files, 1):
+        have, changed = backfill_file(fp, freq_counts, args.source, args.dry_run)
+        total_entries_have += have
+        total_changed      += changed
+        if changed:
+            total_files_touched += 1
+
+        now = time.perf_counter()
+        if now - last_report >= 3.0:
+            last_report = now
+            bd.Progress.bar_line(
+                i, len(files),
+                f"{i:,}/{len(files):,} files  "
+                f"{total_entries_have:,} entries with freq  "
+                f"{total_changed:,} changed",
+            )
+
+    bd.Progress.ok(
+        f"{total_files_touched:,} ファイル更新  "
+        f"{total_entries_have:,} エントリに {args.source} 頻度  "
+        f"{total_changed:,} 件変更"
+        + ("（dry-run: 未書き込み）" if args.dry_run else "")
+    )
+    bd.Progress.endgroup()
+    log.info("完了: %.1fs", time.perf_counter() - start)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/build_dictionary.py
+++ b/script/build_dictionary.py
@@ -325,6 +325,8 @@ class OutputRecord:
     pos:                 list[str]
     freq_rank:           Optional[int]
     senses:              list[SenseOutput]
+    # 出典別の総出現回数。例: {"aozora": 1234}。疎フィールド（ヒット時のみ設定）
+    frequencies:         dict[str, int] = field(default_factory=dict)
 
 
 # ──────────────────────────────────────────────────────────
@@ -397,6 +399,11 @@ def record_to_dict(rec: OutputRecord, updated_at: str) -> dict:
     }
     if rec.freq_rank is not None:
         meta["freq_rank"] = rec.freq_rank
+    if rec.frequencies:
+        # ソース名 → 総出現回数。出現の多い順にソートして安定出力
+        meta["frequencies"] = dict(
+            sorted(rec.frequencies.items(), key=lambda kv: (-kv[1], kv[0]))
+        )
 
     return {
         "uuid":  rec.uuid,
@@ -1121,6 +1128,318 @@ def attach_aozora_examples(
 
 
 # ──────────────────────────────────────────────────────────
+# Phase 4.6: 青空文庫 頻度カウント（形態素解析）
+#
+# 例句収集（部分文字列マッチ）とは別パラダイム。Sudachi で本文を
+# 形態素解析し、内容語の dictionary_form（表記を保った原形）を
+# キーに総出現回数を数える。語境界・活用を考慮するため、部分文字列
+# マッチのような誤検出（短語が他語の一部に一致 等）が起きない。
+#
+# 注意:
+#   - 底本/奥付（フッタ）と、冒頭の記法説明ブロック（2本の区切り線に
+#     挟まれた「【テキスト中に現れる記号について】」等）は本文から除外し、
+#     頻度に含めない。
+#   - dictionary_form をキーにするため、同表記・同原形の異音異義語
+#     （例: 辛い=からい/つらい）は合算される（= 総出現回数の定義に一致）。
+# ──────────────────────────────────────────────────────────
+
+_FREQ_CHECKPOINT_NAME = "aozora_freq_checkpoint.json.gz"  # {tmp_dir}/ 以下に保存
+_FREQ_TABLE_NAME      = "aozora_freq.json.gz"             # 再利用可能な頻度テーブル
+
+# 奥付（底本情報）を検出するための行頭マーカー。これらで始まる行以降は
+# 本文ではないと判断し、頻度カウントから除外する。
+_FREQ_FOOTER_MARKERS = frozenset([
+    "底本：", "底本:", "底本の親本：", "初出：", "初出:",
+    "入力：", "入力:", "入力者：", "校正：", "校正:", "校正者：",
+    "翻訳者：", "翻訳:", "青空文庫作成ファイル", "●表記について",
+    "【テキスト中",
+])
+
+# 区切り線（記法説明ブロックの境界）を構成しうる文字
+_DELIM_CHARS = set("-‐‑‒–—―─━")
+
+# カウント対象外の品詞（大分類）
+_FREQ_SKIP_POS = frozenset(["助詞", "助動詞", "補助記号", "空白", "記号"])
+
+# 各ワーカープロセスで 1 度だけ生成する Sudachi トークナイザ
+_FREQ_TOKENIZER = None
+
+
+def _get_freq_tokenizer():
+    """ワーカープロセスごとに Sudachi トークナイザを遅延生成する。"""
+    global _FREQ_TOKENIZER
+    if _FREQ_TOKENIZER is None:
+        from sudachipy import dictionary  # 遅延 import（未インストール時は呼び出し側で警告）
+        _FREQ_TOKENIZER = dictionary.Dictionary(dict="core").create()
+    return _FREQ_TOKENIZER
+
+
+def _is_delim_line(line: str) -> bool:
+    """記法説明ブロックの区切り線か（ハイフン等が 8 文字以上連続）"""
+    s = line.strip()
+    return len(s) >= 8 and all(c in _DELIM_CHARS for c in s)
+
+
+def _extract_aozora_body_text(lines: list[str]) -> str:
+    """
+    青空文庫テキストから「本文」だけを抽出する（頻度カウント用）。
+      - 冒頭の記法説明ブロック（2 本の区切り線に挟まれた部分）を除外
+      - 奥付（フッタ）以降を除外
+      - ルビ/注記/外字マークアップを除去
+    """
+    # 冒頭 60 行内に区切り線が 2 本以上あれば、2 本目以降を本文開始とみなす
+    delim_idx = [i for i, l in enumerate(lines[:60]) if _is_delim_line(l)]
+    start = delim_idx[1] + 1 if len(delim_idx) >= 2 else 0
+
+    body: list[str] = []
+    for line in lines[start:]:
+        st = line.strip()
+        if st and any(st.startswith(m) for m in _FREQ_FOOTER_MARKERS):
+            break  # 奥付に到達。以降は本文ではない
+        body.append(strip_aozora_markup(line))
+    return "\n".join(body)
+
+
+def _safe_chunks(s: str, limit: int = 40000):
+    """Sudachi の入力長上限（約 49149 バイト）を超えないよう句点で分割する。"""
+    if len(s.encode("utf-8")) <= limit:
+        yield s
+        return
+    buf = ""
+    for part in re.split(r"(?<=。)", s):
+        if buf and len((buf + part).encode("utf-8")) > limit:
+            yield buf
+            buf = part
+        else:
+            buf += part
+    if buf:
+        yield buf
+
+
+def _freq_worker(file_paths: list[str]) -> tuple[dict[str, int], int, int]:
+    """
+    ProcessPoolExecutor 用ワーカー（モジュールレベル必須）。
+    Returns: (partial_counts, processed_files, counted_tokens)
+    """
+    from sudachipy import SplitMode  # 遅延 import
+    tok = _get_freq_tokenizer()
+    counts: dict[str, int] = defaultdict(int)
+    files_done = 0
+    tokens_done = 0
+
+    for path_str in file_paths:
+        try:
+            txt_file = Path(path_str)
+            try:
+                content = txt_file.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                content = txt_file.read_text(encoding="shift_jis", errors="replace")
+
+            body = _extract_aozora_body_text(content.splitlines())
+            for raw_line in body.split("\n"):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                for chunk in _safe_chunks(line):
+                    try:
+                        morphemes = tok.tokenize(chunk, SplitMode.C)
+                    except Exception:
+                        continue  # 解析不能な行はスキップ
+                    for m in morphemes:
+                        if m.part_of_speech()[0] in _FREQ_SKIP_POS:
+                            continue
+                        lemma = m.dictionary_form()
+                        if not lemma or not is_japanese_text(lemma):
+                            continue
+                        counts[lemma] += 1
+                        tokens_done += 1
+            files_done += 1
+        except Exception:
+            files_done += 1  # スキップしてもカウント
+            continue
+
+    return dict(counts), files_done, tokens_done
+
+
+def _save_freq_checkpoint(
+    checkpoint_path: Path,
+    processed_files: set[str],
+    counts: dict[str, int],
+) -> None:
+    """頻度チェックポイントをアトミックに保存する（gzip JSON）"""
+    tmp_path = checkpoint_path.with_name(checkpoint_path.name + ".tmp")
+    data = {"processed_files": list(processed_files), "counts": counts}
+    try:
+        with gzip.open(tmp_path, "wt", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False)
+        tmp_path.rename(checkpoint_path)
+    except Exception as exc:
+        tmp_path.unlink(missing_ok=True)
+        log.warning("頻度チェックポイント保存失敗: %s", exc)
+
+
+def _load_freq_checkpoint(
+    checkpoint_path: Path,
+) -> tuple[dict[str, int], set[str]]:
+    """頻度チェックポイントを読み込む。失敗時は空を返す。"""
+    try:
+        with gzip.open(checkpoint_path, "rt", encoding="utf-8") as f:
+            data = json.load(f)
+        counts   = data.get("counts", {})
+        proc_set = set(data.get("processed_files", []))
+        log.info("頻度チェックポイント読み込み: %d 語, %d ファイル処理済み",
+                 len(counts), len(proc_set))
+        return counts, proc_set
+    except Exception as exc:
+        log.warning("頻度チェックポイント読み込み失敗（無視）: %s", exc)
+        return {}, set()
+
+
+def build_corpus_frequency(
+    aozora_dir: Path,
+    n_workers: int = 1,
+    checkpoint_path: Optional[Path] = None,
+    table_path: Optional[Path] = None,
+    resume: bool = False,
+) -> dict[str, int]:
+    """
+    青空文庫テキストを形態素解析し、{dictionary_form: 総出現回数} を構築する。
+    Sudachi 未インストール時は空 dict を返す（警告のみ）。
+    """
+    if not aozora_dir.exists():
+        Progress.warn(f"青空文庫ディレクトリなし: {aozora_dir}")
+        return {}
+
+    # Sudachi の存在チェック（メインプロセスで早期に検出）
+    try:
+        _get_freq_tokenizer()
+    except Exception as exc:
+        Progress.warn(f"Sudachi が利用できないため頻度カウントをスキップ: {exc}")
+        Progress.warn("`pip install -r requirements.txt` で sudachipy / sudachidict_core を導入してください")
+        return {}
+
+    Progress.group(f"Phase 4.6 │ 青空文庫 頻度カウント（形態素解析, workers={n_workers}）")
+
+    counts: dict[str, int] = defaultdict(int)
+    already_processed: set[str] = set()
+    if resume and checkpoint_path and checkpoint_path.exists():
+        preloaded, already_processed = _load_freq_checkpoint(checkpoint_path)
+        for w, c in preloaded.items():
+            counts[w] += c
+        Progress.step(f"チェックポイント復元: {len(already_processed):,} ファイル処理済み  "
+                      f"{len(counts):,} 語")
+
+    all_txt_files = sorted(aozora_dir.rglob("*.txt"))
+    txt_files = [f for f in all_txt_files if str(f) not in already_processed]
+    total_files     = len(all_txt_files)
+    remaining_files = len(txt_files)
+    Progress.step(f"対象テキスト: {remaining_files:,} / {total_files:,} ファイル  workers: {n_workers}")
+
+    n_chunks   = max(n_workers, n_workers * 8)
+    chunk_size = max(1, (remaining_files + n_chunks - 1) // n_chunks)
+    chunks: list[list[str]] = [
+        [str(f) for f in txt_files[i: i + chunk_size]]
+        for i in range(0, remaining_files, chunk_size)
+    ]
+
+    done_files      = len(already_processed)
+    done_tokens     = 0
+    phase_t         = time.perf_counter()
+    last_report     = phase_t
+    last_checkpoint = phase_t
+    processed_in_run: set[str] = set()
+
+    shutdown_evt = threading.Event()
+    _orig_sigint = signal.getsignal(signal.SIGINT)
+
+    def _sigint_handler(sig: int, frame: object) -> None:
+        print("\n[SIGINT] 終了要求を受信しました。チェックポイント保存後に終了します...",
+              flush=True)
+        shutdown_evt.set()
+
+    signal.signal(signal.SIGINT, _sigint_handler)
+
+    try:
+        with ProcessPoolExecutor(max_workers=n_workers) as pool:
+            futures_map = {
+                pool.submit(_freq_worker, chunk): chunk for chunk in chunks
+            }
+            for fut in as_completed(futures_map):
+                if shutdown_evt.is_set():
+                    for pending in futures_map:
+                        pending.cancel()
+                    break
+
+                chunk_files_list = futures_map[fut]
+                partial, chunk_files, chunk_tokens = fut.result()
+                done_files  += chunk_files
+                done_tokens += chunk_tokens
+                processed_in_run.update(chunk_files_list)
+
+                for word, c in partial.items():
+                    counts[word] += c
+
+                now = time.perf_counter()
+                if checkpoint_path and now - last_checkpoint >= _CHECKPOINT_SEC:
+                    last_checkpoint = now
+                    all_proc = already_processed | processed_in_run
+                    _save_freq_checkpoint(checkpoint_path, all_proc, dict(counts))
+
+                if now - last_report >= _REPORT_SEC:
+                    last_report = now
+                    Progress.bar_line(
+                        done_files, total_files,
+                        f"{done_files:>6,} / {total_files:,} files  "
+                        f"{len(counts):,} 語  {done_tokens:,} tokens",
+                    )
+    finally:
+        signal.signal(signal.SIGINT, _orig_sigint)
+        if checkpoint_path:
+            all_proc = already_processed | processed_in_run
+            _save_freq_checkpoint(checkpoint_path, all_proc, dict(counts))
+            log.info("頻度チェックポイント保存完了: %s", checkpoint_path)
+
+    if shutdown_evt.is_set():
+        print(f"  頻度チェックポイント保存完了: {checkpoint_path}", flush=True)
+        sys.exit(130)
+
+    result = dict(counts)
+    # 再利用可能な頻度テーブルを永続化
+    if table_path:
+        try:
+            with gzip.open(table_path, "wt", encoding="utf-8") as f:
+                json.dump(result, f, ensure_ascii=False)
+            Progress.step(f"頻度テーブル保存: {table_path}")
+        except Exception as exc:
+            log.warning("頻度テーブル保存失敗: %s", exc)
+
+    Progress.ok(f"{done_files:,} ファイル  {done_tokens:,} tokens  {len(result):,} 語")
+    Progress.endgroup()
+    return result
+
+
+def attach_corpus_frequency(
+    records: list[OutputRecord],
+    freq_counts: dict[str, int],
+    source: str = "aozora",
+) -> int:
+    """
+    各レコードの見出し語（entry = dictionary_form 相当）で頻度テーブルを引き、
+    meta.frequencies[source] に総出現回数を付与する（in-place）。
+    ヒット件数を返す。
+    """
+    if not freq_counts:
+        return 0
+    attached = 0
+    for rec in records:
+        c = freq_counts.get(rec.entry, 0)
+        if c > 0:
+            rec.frequencies[source] = c
+            attached += 1
+    return attached
+
+
+# ──────────────────────────────────────────────────────────
 # Phase 5: 読みでグループ化
 # ──────────────────────────────────────────────────────────
 
@@ -1263,6 +1582,8 @@ def main() -> None:
                         help="git pull をスキップ")
     parser.add_argument("--no-aozora",   action="store_true",
                         help="青空文庫例句付与をスキップ")
+    parser.add_argument("--no-frequency", action="store_true",
+                        help="青空文庫の頻度カウント（形態素解析）をスキップ")
     parser.add_argument("--verbose",     action="store_true",
                         help="DEBUG ログを出力")
     parser.add_argument("--dry-run",     action="store_true",
@@ -1324,6 +1645,19 @@ def main() -> None:
         attach_aozora_examples(records, sentence_index)
         aozora_matched = len(sentence_index)
 
+    # ── Phase 4.6: 青空文庫 頻度カウント ──────────────────
+    aozora_freq_attached = 0
+    if not args.no_frequency:
+        aozora_dir       = args.tmp_dir / "aozorabunko_text"
+        freq_ckpt_path   = args.tmp_dir / _FREQ_CHECKPOINT_NAME
+        freq_table_path  = args.tmp_dir / _FREQ_TABLE_NAME
+        freq_counts = build_corpus_frequency(
+            aozora_dir, n_workers=n_workers,
+            checkpoint_path=freq_ckpt_path, table_path=freq_table_path,
+            resume=args.resume,
+        )
+        aozora_freq_attached = attach_corpus_frequency(records, freq_counts, source="aozora")
+
     # ── Phase 5: グループ化 ────────────────────────────────
     Progress.group("Phase 5 │ 読みでグループ化")
     grouped = group_by_reading(records)
@@ -1353,6 +1687,7 @@ def main() -> None:
     print(f"  Total entries output      : {total_entries:>10,}", flush=True)
     print(f"  Frequency matched         : {freq_matched:>10,}", flush=True)
     print(f"  Aozora words with examples: {aozora_matched:>10,}", flush=True)
+    print(f"  Aozora frequency attached : {aozora_freq_attached:>10,}", flush=True)
     print(f"  Output directories used   : {used_dirs:>10,}", flush=True)
     print(f"  Elapsed time              : {elapsed:>10.1f}s", flush=True)
     print(f"  Peak memory               : {peak_mem / 1e6:>10.1f} MB", flush=True)


### PR DESCRIPTION
## Summary

- 辞典エントリに「指定コーパス内での総出現回数」を表す `meta.frequencies`（出典名→回数。例 `{"aozora": 1234}`）を追加。将来複数ソース対応前提のオブジェクト構造で、既存の `meta.freq_rank`（順位）とは別概念として共存。
- 第一弾として青空文庫（aozora）を対象。形態素解析（Sudachi）で語境界・活用を考慮した正確なカウントを行う。
- API がこの新フィールドを返せるようにスキーマと生成コードを更新。
- 既存 `data/` の enrich（AI 生成例文など）を壊さず頻度だけ注入する in-place バックフィルスクリプトを同梱。

## Changes

| 領域 | 変更 |
|---|---|
| `script/build_dictionary.py` | `build_corpus_frequency`（Sudachi `SplitMode.C`、`dictionary_form` キーで総出現回数を集計）/ `attach_corpus_frequency` を新設。**底本・奥付（フッタ）と冒頭の記法説明ブロックを本文から除外**し頻度に含めない。`OutputRecord.frequencies` / `record_to_dict` / `main` 配線、`--no-frequency`・チェックポイント・`aozora_freq.json.gz` キャッシュ対応 |
| `script/backfill_frequency.py`（新規） | 既存 `data/**/*.json` を再生成せず `meta.frequencies` のみ in-place 注入。既存形式（`indent=2`・末尾改行なし）に厳密一致させ整形差分なし。冪等・`--dry-run`・`--freq-table`（事前生成物流用）対応 |
| `api/openapi.yaml` / `api/internal/api/genji.gen.go` | `EntryMeta` に `frequencies`(map[string]int) と `freq_rank` を追加し再生成。`store`/`handlers` は raw_json 透過で変更不要 |
| `requirements.txt`（新規） | `sudachipy` / `sudachidict_core`（ローカルのデータ生成にのみ必要。CI は不要） |

## 設計メモ

- カウント単位は**総出現回数**。`dictionary_form` をキーにするため、同表記・同原形の異音異義語は合算される（= 総出現回数の定義に一致）。
- `build_dictionary.py` はローカル専用ツールで CI では走らない。値が API/DB に乗るのは `data/` をコミットした後、CI（`json_to_sqlite.py`）が自動で genji.db 化・配信する。
- フル再実行は後付けの AI 生成例文を失うため、既存データへの反映はバックフィル方式を推奨。

## Test plan

- [x] `go build` / `go vet` / `go test`（api 配下）全緑
- [x] 本文抽出・カウントの単体テスト（猫=2/吾輩=2、奥付語=0）
- [x] パイプライン結合テスト（ビルダー→テーブル永続化→join→`record_to_dict` JSON 形）
- [x] バックフィルの実データ検証（差分は `meta.frequencies` 追加のみ・再整形なし・冪等）
- [ ] 実コーパスでの本番バックフィル → `data/` コミット（重い処理のため別途実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)