### PR TITLE
fix(ci): push GHCR image to repository owner namespace

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -93,6 +93,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # GHCR は namespace が小文字でなければならないため owner を小文字化する
+      - name: Resolve image owner (lowercase)
+        id: owner
+        run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -102,5 +107,5 @@ jobs:
           build-args: |
             GENJI_DB_SOURCE=local
           tags: |
-            ghcr.io/iktahana/genji-api:latest
-            ghcr.io/iktahana/genji-api:${{ needs.build-and-release.outputs.version }}
+            ghcr.io/${{ steps.owner.outputs.owner }}/genji-api:latest
+            ghcr.io/${{ steps.owner.outputs.owner }}/genji-api:${{ needs.build-and-release.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ SQLite を直接使用できない環境向けに、Go + Gin 製の **OpenAPI-fi
 | `GET /docs` | API ドキュメント（Redoc） |
 
 ```bash
-docker pull ghcr.io/iktahana/genji-api:latest
-docker run -p 8080:8080 ghcr.io/iktahana/genji-api:latest
+docker pull ghcr.io/illusions-lab/genji-api:latest
+docker run -p 8080:8080 ghcr.io/illusions-lab/genji-api:latest
 # http://localhost:8080/docs で仕様を閲覧
 ```
 
@@ -89,8 +89,8 @@ SELECT * FROM _metadata;
 API の Docker イメージは GHCR で配布しています（`linux/amd64` / `linux/arm64` 対応、`genji.db` 内蔵）。
 
 ```bash
-docker pull ghcr.io/iktahana/genji-api:latest
-docker run -p 8080:8080 ghcr.io/iktahana/genji-api:latest
+docker pull ghcr.io/illusions-lab/genji-api:latest
+docker run -p 8080:8080 ghcr.io/illusions-lab/genji-api:latest
 ```
 
 ローカルからビルドして起動する場合:

--- a/api/README.md
+++ b/api/README.md
@@ -204,9 +204,9 @@ docker run -p 8080:8080 -e GENJI_REDIS_ADDR=host.docker.internal:6379 genji-api
 multi-arch（amd64/arm64）でビルドし、SQLite リリースと同じ日付ベースのバージョン（`YYYY.M.D.HHMMSS`）+ `latest` で公開する。
 
 ```bash
-docker pull ghcr.io/iktahana/genji-api:latest
+docker pull ghcr.io/illusions-lab/genji-api:latest
 # または特定版
-docker pull ghcr.io/iktahana/genji-api:2026.4.1.120000
+docker pull ghcr.io/illusions-lab/genji-api:2026.4.1.120000
 ```
 
 ## アーキテクチャ


### PR DESCRIPTION
## Summary

- GHCR への Docker イメージ push が `denied: permission_denied: The requested installation does not exist` で失敗していたのを修正
- `GITHUB_TOKEN` はリポジトリ所有者（org `illusions-lab`）にスコープされるため、個人 namespace `ghcr.io/iktahana/genji-api` へは push できない
- push 先を `ghcr.io/<repository_owner>/genji-api` に変更（owner は GHCR 仕様に合わせ小文字化）

## Changes

| ファイル | 変更 |
|---|---|
| `.github/workflows/build-and-release.yml` | owner を小文字化する step 追加 + tags を `${{ steps.owner.outputs.owner }}/genji-api` に変更 |
| `README.md` / `api/README.md` | `docker pull` の例を `ghcr.io/illusions-lab/genji-api` に更新 |

## Test plan

- [ ] main マージ後の Actions で `docker` ジョブの「Build and push」が成功する
- [ ] `ghcr.io/illusions-lab/genji-api:latest` と `:YYYY.M.D.HHMMSS` が GHCR に公開される